### PR TITLE
fix(highlights): Order HL from differents entities on SF provider

### DIFF
--- a/symfony/src/Services/State/Provider/MainHighlightedItemsProvider.php
+++ b/symfony/src/Services/State/Provider/MainHighlightedItemsProvider.php
@@ -28,6 +28,11 @@ class MainHighlightedItemsProvider implements ProviderInterface
             $this->actorRepository->findHighlightedItems($highlightedItemsItemIds),
         );
 
+        $idOrder = array_flip($highlightedItemsItemIds);
+        usort($items, function ($a, $b) use ($idOrder) {
+            return ($idOrder[$a->getItemId()] ?? PHP_INT_MAX) <=> ($idOrder[$b->getItemId()] ?? PHP_INT_MAX);
+        });
+
         return $items;
     }
 }

--- a/symfony/src/Services/State/Provider/MainHighlightedItemsProvider.php
+++ b/symfony/src/Services/State/Provider/MainHighlightedItemsProvider.php
@@ -30,7 +30,7 @@ class MainHighlightedItemsProvider implements ProviderInterface
 
         $idOrder = array_flip($highlightedItemsItemIds);
         usort($items, function ($a, $b) use ($idOrder) {
-            return ($idOrder[$a->getItemId()] ?? PHP_INT_MAX) <=> ($idOrder[$b->getItemId()] ?? PHP_INT_MAX);
+            return ($idOrder[$b->getItemId()] ?? PHP_INT_MAX) <=> ($idOrder[$a->getItemId()] ?? PHP_INT_MAX);
         });
 
         return $items;


### PR DESCRIPTION
J'ai mis à jours l'ordre des mains HL qui buggait quand ils étaient composés de différentes entités